### PR TITLE
Explicit the executor used by the gitlab runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ GitLab Runner is a continuous integration tool to use with a GitLab instance (YN
 
 How to configure this app: by the admin panel of GitLab or the settings "CI/CD" of your project.
 
+### System configuration
+
+Running a Gitlab Runner mandates to choose [an executor](https://docs.gitlab.com/runner/executors/) at registeration time (when the Gitlab Runner instance registers to a Gitlab instance). For now this YunoHost application only supports the `docker` executor.
+
 ## Documentation
 
  * Official documentation: https://docs.gitlab.com/runner/

--- a/README_fr.md
+++ b/README_fr.md
@@ -21,6 +21,10 @@ GitLab Runner est un outil d'intégration continue à utiliser avec une instance
 
 Comment configurer cette application: via le panneau d'administration de GitLab ou les paramettres "CI/CD" de votre projet.
 
+### Configuration système
+
+Lors du premier démarrage d'un Gitlab Runner, [un exécuteur](https://docs.gitlab.com/runner/executors/) doit être choisi (Lorsque l'instance Gitlab Runner s'enregistre auprès d'une instance Gitlab). Pour l'instant, cette application YunoHost ne supporte que l'[exécuteur `docker`](https://docs.gitlab.com/runner/executors/docker.html).
+
 ## Documentation
 
  * Documentation officielle : https://docs.gitlab.com/runner/


### PR DESCRIPTION
Hello,

By reading the readme it was unclear for me how to choose the Gitlab Runner executor used by this yunohost application.

The PR explicits the fact only [the docker executor is supported for now](https://github.com/YunoHost-Apps/gitlab-runner_ynh/blob/ae4056be66236a892d61859d673a5a5684cee075/scripts/install#L53-L54).