### PR TITLE
Update SHA for x86_64 

### DIFF
--- a/scripts/upgrade.d/upgrade.last.sh
+++ b/scripts/upgrade.d/upgrade.last.sh
@@ -1,6 +1,6 @@
 gitlab_runner_version="13.11.0"
 
-gitlab_runner_x86_64_source_sha256="449af4853475f34508252469117e9bf61ed91b671d271becf377d9ff4735e512"
+gitlab_runner_x86_64_source_sha256="970426bec5aa8683345efb49a746cd45ccbd82541dca1d020a9f87075cc27159"
 
 gitlab_runner_i386_source_sha256="928e1afd5b2f81576382e579e4b10296038e7f94d9d634bb0f35248af36a1571"
 


### PR DESCRIPTION
Updated SHA to match what I get when I download that file, if your milage differs, there would seem to be a more suspicious issue.

## Problem

see: https://github.com/YunoHost-Apps/gitlab-runner_ynh/issues/32

## PR Status

- [x ] Code finished and ready to be reviewed/tested
- [x ] The fix/enhancement were manually tested (if applicable)


