### PR TITLE
Changed packages url to follow the redirection to gitlab's amazon S3 repository

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -57,13 +57,13 @@ ram.runtime = "50M"
 [resources]
     [resources.sources.main]
     rename = "gitlab-runner.deb"
-    amd64.url = "https://gitlab.com/gitlab-org/gitlab-runner/-/releases/v17.3.1/downloads/packages/deb/gitlab-runner_amd64.deb"
+    amd64.url = "https://gitlab-runner-downloads.s3.amazonaws.com/v17.3.1/deb/gitlab-runner_amd64.deb"
     amd64.sha256 = "e9642903469cf1842f1c7fcf4a11a2994629f4aed36639cda1a212b562a12f9e"
-    i386.url = "https://gitlab.com/gitlab-org/gitlab-runner/-/releases/v17.3.1/downloads/packages/deb/gitlab-runner_i386.deb"
+    i386.url = "https://gitlab-runner-downloads.s3.amazonaws.com/v17.3.1/deb//gitlab-runner_i386.deb"
     i386.sha256 = "b648947a02361188886043a38ccd8b0c2ee242df3a171fb069ee59a379f6b616"
-    arm64.url = "https://gitlab.com/gitlab-org/gitlab-runner/-/releases/v17.3.1/downloads/packages/deb/gitlab-runner_arm64.deb"
+    arm64.url = "https://gitlab-runner-downloads.s3.amazonaws.com/v17.3.1/deb/gitlab-runner_arm64.deb"
     arm64.sha256 = "fcdee00728d9d0fe7d50e014d6c26adceeec75712b92d765553898ebb051e724"
-    armhf.url = "https://gitlab.com/gitlab-org/gitlab-runner/-/releases/v17.3.1/downloads/packages/deb/gitlab-runner_armhf.deb"
+    armhf.url = "https://gitlab-runner-downloads.s3.amazonaws.com/v17.3.1/deb/gitlab-runner_armhf.deb"
     armhf.sha256 = "6c2d730e2e778a72244518352dd3189803fd627226202c596264edade3ba5772"
 
     autoupdate.upstream = "https://gitlab.com/gitlab-org/gitlab-runner"


### PR DESCRIPTION
Changed packages url to follow the redirection to gitlab's amazon S3 repository

## Problem

- An error is prompted when installing or upgrading the gitlab runner on yunohost due to an invalid checksum.

## Solution

- The URL of the .deb packages changed to AWS S3, as specified when trying the download links of the manifest in a browser. I only changed the URL, checksums remains the same.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
